### PR TITLE
Allow to create index even when only (one) sitemap.xml exists

### DIFF
--- a/src/main/java/com/redfin/sitemapgenerator/SitemapIndexGenerator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/SitemapIndexGenerator.java
@@ -187,12 +187,20 @@ public class SitemapIndexGenerator {
 	 * @param count the number of sitemaps (1-based)
 	 */
 	public SitemapIndexGenerator addUrls(String prefix, String suffix, int count) {
-		for (int i = 1; i <= count; i++) {
-			String fileName = prefix + i + suffix;
+		if (count == 0) {
 			try {
-				addUrl(new URL(baseUrl, fileName));
+				addUrl(new URL(baseUrl, prefix + suffix));
 			} catch (MalformedURLException e) {
 				throw new RuntimeException(e);
+			}
+		} else {
+			for (int i = 1; i <= count; i++) {
+				String fileName = prefix + i + suffix;
+				try {
+					addUrl(new URL(baseUrl, fileName));
+				} catch (MalformedURLException e) {
+					throw new RuntimeException(e);
+				}
 			}
 		}
 		return this;


### PR DESCRIPTION
This is a fix for https://code.google.com/p/sitemapgen4j/issues/detail?id=8
When the number of total urls is smaller than maxUrls (50 000) and then using `writeSitemapsWithIndex` "only" the `sitemap.xml` will be generated and the `count` of sitemaps (e.g. sitemap1.xml, sitemap2.xml) is 0.
As a result when trying to write the Sitemap index file with `writeSitemapsWithIndex` we get an exception:

```
 java.lang.RuntimeException: No URLs added, sitemap index would be empty; you must add some URLs with addUrls
```

This pull request is basically the patch from [comment 8](https://code.google.com/p/sitemapgen4j/issues/detail?id=8#c3).

@dfabulich Could you please merge and also release a new version? Thanks!
