### PR TITLE
Adding support for custom suffix indexes for sitemap generation

### DIFF
--- a/src/main/java/com/redfin/sitemapgenerator/AbstractSitemapGeneratorOptions.java
+++ b/src/main/java/com/redfin/sitemapgenerator/AbstractSitemapGeneratorOptions.java
@@ -6,68 +6,81 @@ import java.net.URL;
 // that weird thing with generics is so sub-classed objects will return themselves
 // It makes sense, I swear! http://madbean.com/2004/mb2004-3/
 abstract class AbstractSitemapGeneratorOptions<THIS extends AbstractSitemapGeneratorOptions<THIS>> {
-	File baseDir;
-	URL baseUrl;
-	String fileNamePrefix = "sitemap";
-	boolean allowMultipleSitemaps = true;
-	W3CDateFormat dateFormat;
-	int maxUrls = SitemapGenerator.MAX_URLS_PER_SITEMAP;
-	boolean autoValidate = false;
-	boolean gzip = false;
-	
-	public AbstractSitemapGeneratorOptions(URL baseUrl, File baseDir) {
-		if (baseUrl == null) throw new NullPointerException("baseUrl may not be null");
-		this.baseDir = baseDir;
-		this.baseUrl = baseUrl;
-	}
-	
-	public AbstractSitemapGeneratorOptions(URL baseUrl) {
-		this(baseUrl, null);
-	}
-	
-	/** The prefix of the name of the sitemaps we'll create; by default this is "sitemap" */
-	public THIS fileNamePrefix(String fileNamePrefix) {
-		if (fileNamePrefix == null) throw new NullPointerException("fileNamePrefix may not be null");
-		this.fileNamePrefix = fileNamePrefix;
-		return getThis();
-	}
-	/** When more than the maximum number of URLs are passed in, should we split into multiple sitemaps automatically, or just throw an exception? */
-	public THIS allowMultipleSitemaps(boolean allowMultipleSitemaps) {
-		this.allowMultipleSitemaps = allowMultipleSitemaps;
-		return getThis();
-	}
-	/** The date formatter, typically configured with a {@link W3CDateFormat.Pattern} and/or a time zone */
-	public THIS dateFormat(W3CDateFormat dateFormat) {
-		this.dateFormat = dateFormat;
-		return getThis();
-	}
-	/**
-	 * The maximum number of URLs to allow per sitemap; the default is the
-	 * maximum allowed (50,000), but you can decrease it if you wish (to make
-	 * your auto-generated sitemaps smaller)
-	 */
-	public THIS maxUrls(int maxUrls) {
-		if (maxUrls > SitemapGenerator.MAX_URLS_PER_SITEMAP) {
-			throw new RuntimeException("You can only have 50,000 URLs per sitemap; to use more, allowMultipleSitemaps and generate a sitemap index. You asked for " + maxUrls);
-		}
-		this.maxUrls = maxUrls;
-		return getThis();
-	}
-	/**
-	 * Validate the sitemaps automatically after writing them; this takes time (and may fail for Google-specific sitemaps)
-	 */
-	public THIS autoValidate(boolean autoValidate) {
-		this.autoValidate = autoValidate;
-		return getThis();
-	}
-	/** Gzip the sitemaps after they are written to disk */
-	public THIS gzip(boolean gzip) {
-		this.gzip = gzip;
-		return getThis();
-	}
-	
-	@SuppressWarnings("unchecked")
-	THIS getThis() {
-		return (THIS)this;
-	}
+    File baseDir;
+    URL baseUrl;
+    String fileNamePrefix = "sitemap";
+    boolean allowMultipleSitemaps = true;
+    boolean addSuffix = true; // use this boolean flag to turn the index on or off.
+    String suffixStringPattern; // this will store some type of string pattern suitable per needs.
+    W3CDateFormat dateFormat;
+    int maxUrls = SitemapGenerator.MAX_URLS_PER_SITEMAP;
+    boolean autoValidate = false;
+    boolean gzip = false;
+
+    public AbstractSitemapGeneratorOptions(URL baseUrl, File baseDir) {
+        if (baseUrl == null) throw new NullPointerException("baseUrl may not be null");
+        this.baseDir = baseDir;
+        this.baseUrl = baseUrl;
+    }
+
+    public AbstractSitemapGeneratorOptions(URL baseUrl) {
+        this(baseUrl, null);
+    }
+
+    /** The prefix of the name of the sitemaps we'll create; by default this is "sitemap" */
+    public THIS fileNamePrefix(String fileNamePrefix) {
+        if (fileNamePrefix == null) throw new NullPointerException("fileNamePrefix may not be null");
+        this.fileNamePrefix = fileNamePrefix;
+        return getThis();
+    }
+
+    public THIS suffixStringPattern(String pattern) {
+        this.suffixStringPattern = pattern;
+        return getThis();
+    }
+
+    public THIS addSuffix(boolean addSuffix) {
+        this.addSuffix = addSuffix;
+        return getThis();
+    }
+
+    /** When more than the maximum number of URLs are passed in, should we split into multiple sitemaps automatically, or just throw an exception? */
+    public THIS allowMultipleSitemaps(boolean allowMultipleSitemaps) {
+        this.allowMultipleSitemaps = allowMultipleSitemaps;
+        return getThis();
+    }
+    /** The date formatter, typically configured with a {@link W3CDateFormat.Pattern} and/or a time zone */
+    public THIS dateFormat(W3CDateFormat dateFormat) {
+        this.dateFormat = dateFormat;
+        return getThis();
+    }
+    /**
+     * The maximum number of URLs to allow per sitemap; the default is the
+     * maximum allowed (50,000), but you can decrease it if you wish (to make
+     * your auto-generated sitemaps smaller)
+     */
+    public THIS maxUrls(int maxUrls) {
+        if (maxUrls > SitemapGenerator.MAX_URLS_PER_SITEMAP) {
+            throw new RuntimeException("You can only have 50,000 URLs per sitemap; to use more, allowMultipleSitemaps and generate a sitemap index. You asked for " + maxUrls);
+        }
+        this.maxUrls = maxUrls;
+        return getThis();
+    }
+    /**
+     * Validate the sitemaps automatically after writing them; this takes time (and may fail for Google-specific sitemaps)
+     */
+    public THIS autoValidate(boolean autoValidate) {
+        this.autoValidate = autoValidate;
+        return getThis();
+    }
+    /** Gzip the sitemaps after they are written to disk */
+    public THIS gzip(boolean gzip) {
+        this.gzip = gzip;
+        return getThis();
+    }
+
+    @SuppressWarnings("unchecked")
+    THIS getThis() {
+        return (THIS)this;
+    }
 }

--- a/src/main/java/com/redfin/sitemapgenerator/SitemapGenerator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/SitemapGenerator.java
@@ -10,7 +10,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
-
+import com.sun.deploy.util.StringUtils;
 import org.xml.sax.SAXException;
 
 abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGenerator<U,THIS>> {
@@ -30,7 +30,6 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 	private final ISitemapUrlRenderer<U> renderer;
 	private int mapCount = 0;
 	private boolean finished = false;
-	
 	private final ArrayList<File> outFiles = new ArrayList<File>();
 	
 	public SitemapGenerator(AbstractSitemapGeneratorOptions<?> options, ISitemapUrlRenderer<U> renderer) {
@@ -45,7 +44,12 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 		autoValidate = options.autoValidate;
 		gzip = options.gzip;
 		this.renderer = renderer;
-		fileNameSuffix = gzip ? ".xml.gz" : ".xml";
+        if(options.addSuffix && options.suffixStringPattern != null && !options.suffixStringPattern.isEmpty()) {
+            fileNameSuffix = gzip ? options.suffixStringPattern + ".xml.gz" : options.suffixStringPattern + ".xml";
+        }
+        else {
+            fileNameSuffix = gzip ? ".xml.gz" : ".xml";
+        }
 	}
 	
 	/** Add one URL of the appropriate type to this sitemap.


### PR DESCRIPTION
@dfabulich please review my change, which incorporates, adding a suffix index ( can be some sort of string pattern ). This can be turned on or off. This property is set via options. when generating the sitemaps. for example in this case it will be - 

WebSitemapGenerator wsg = WebSitemapGenerator.builder( .... all the custom options .. ).build();

Let me know what you think and your comments please! 

Thanks!
Ankita 