### PR TITLE
Close streams in finally clause

### DIFF
--- a/src/main/java/com/redfin/sitemapgenerator/SitemapGenerator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/SitemapGenerator.java
@@ -60,7 +60,7 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 	 * or else write out one sitemap immediately.
 	 * @param url the URL to add to this sitemap
 	 * @return this
-     * @throws IOException when closing of streams has failed
+	 * @throws IOException when closing of streams has failed
 	 */
 	public THIS addUrl(U url) throws IOException {
 		if (finished) throw new RuntimeException("Sitemap already printed; you must create a new generator to make more sitemaps"); 
@@ -83,7 +83,7 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 	 * or write out one sitemap immediately.
 	 * @param urls the URLs to add to this sitemap
 	 * @return this
-     * @throws IOException when closing of streams has failed.
+	 * @throws IOException when closing of streams has failed.
 	 */
 	public THIS addUrls(Iterable<? extends U> urls) throws IOException {
 		for (U url : urls) addUrl(url);
@@ -95,7 +95,7 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 	 * or write out one sitemap immediately.
 	 * @param urls the URLs to add to this sitemap
 	 * @return this
-     * @throws IOException when closing of streams has failed.
+	 * @throws IOException when closing of streams has failed.
 	 */
 	public THIS addUrls(U... urls) throws IOException {
 		for (U url : urls) addUrl(url);
@@ -123,8 +123,8 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 		U sitemapUrl;
 		try {
 			sitemapUrl = renderer.getUrlClass().getConstructor(String.class).newInstance(url);
-            return addUrl(sitemapUrl);
-        } catch (Exception e) {
+			return addUrl(sitemapUrl);
+		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
 	}
@@ -150,8 +150,8 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 		U sitemapUrl;
 		try {
 			sitemapUrl = renderer.getUrlClass().getConstructor(URL.class).newInstance(url);
-            return addUrl(sitemapUrl);
-        } catch (Exception e) {
+			return addUrl(sitemapUrl);
+		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
 	}
@@ -169,10 +169,10 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 		if (finished) throw new RuntimeException("Sitemap already printed; you must create a new generator to make more sitemaps");
 		if (!allowEmptySitemap && urls.isEmpty() && mapCount == 0) throw new RuntimeException("No URLs added, sitemap would be empty; you must add some URLs with addUrls");
 		try {
-            writeSiteMap();
-        } catch (IOException ex) {
-		    throw new RuntimeException("Closing of streams has failed at some point.", ex);
-        }
+			writeSiteMap();
+		} catch (IOException ex) {
+			throw new RuntimeException("Closing of streams has failed at some point.", ex);
+		}
 		finished = true;
 		return outFiles;
 	}
@@ -215,7 +215,7 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 	/**
 	 * After you've called {@link #write()}, call this to generate a sitemap index of all sitemaps you generated.
 	 * The sitemap index is written to {baseDir}/sitemap_index.xml
-     * @throws IOException when closing of streams has failed
+	 * @throws IOException when closing of streams has failed
 	 */
 	public File writeSitemapsWithIndex() throws IOException {
 		if (!finished) throw new RuntimeException("Sitemaps not generated yet; call write() first");
@@ -227,7 +227,7 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 	 * After you've called {@link #write()}, call this to generate a sitemap index of all sitemaps you generated.
 	 *
 	 * @param outFile the destination file of the sitemap index.
-     * @throws IOException when closing of streams has failed
+	 * @throws IOException when closing of streams has failed
 	 */
 	public File writeSitemapsWithIndex(File outFile) throws IOException {
 		if (!finished) throw new RuntimeException("Sitemaps not generated yet; call write() first");
@@ -251,8 +251,8 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 		File outFile = new File(baseDir, fileNamePrefix+fileNameSuffix);
 		outFiles.add(outFile);
 
-        OutputStreamWriter out = null;
-        try {
+		OutputStreamWriter out = null;
+		try {
 			if (gzip) {
 				FileOutputStream fileStream = new FileOutputStream(outFile);
 				GZIPOutputStream gzipStream = new GZIPOutputStream(fileStream);
@@ -270,10 +270,10 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 		} catch (SAXException e) {
 			throw new RuntimeException("Sitemap file failed to validate (bug?)", e);
 		} finally {
-            if(out != null) {
-                out.close();
-            }
-        }
+			if(out != null) {
+				out.close();
+			}
+		}
 	}
 	
 	private void writeSiteMap(OutputStreamWriter out) throws IOException {

--- a/src/main/java/com/redfin/sitemapgenerator/SitemapGenerator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/SitemapGenerator.java
@@ -260,8 +260,10 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 			} else {
 				out = new OutputStreamWriter(new FileOutputStream(outFile), Charset.forName("UTF-8").newEncoder());
 			}
-			
+
 			writeSiteMap(out);
+			out.flush();
+
 			if (autoValidate) SitemapValidator.validateWebSitemap(outFile);
 		} catch (IOException e) {
 			throw new RuntimeException("Problem writing sitemap file " + outFile, e);

--- a/src/main/java/com/redfin/sitemapgenerator/SitemapGenerator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/SitemapGenerator.java
@@ -60,16 +60,19 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 	 * or else write out one sitemap immediately.
 	 * @param url the URL to add to this sitemap
 	 * @return this
-	 * @throws IOException when closing of streams has failed
 	 */
-	public THIS addUrl(U url) throws IOException {
+	public THIS addUrl(U url) {
 		if (finished) throw new RuntimeException("Sitemap already printed; you must create a new generator to make more sitemaps"); 
 		UrlUtils.checkUrl(url.getUrl(), baseUrl);
 		if (urls.size() == maxUrls) {
 			if (!allowMultipleSitemaps) throw new RuntimeException("More than " + maxUrls + " urls, but allowMultipleSitemaps is false.  Enable allowMultipleSitemaps to split the sitemap into multiple files with a sitemap index.");
 			if (baseDir != null) {
 				if (mapCount == 0) mapCount++;
-				writeSiteMap();
+				try {
+					writeSiteMap();
+				} catch(IOException ex) {
+					throw new RuntimeException("Closing of stream failed.", ex);
+				}
 				mapCount++;
 				urls.clear();
 			}
@@ -83,9 +86,8 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 	 * or write out one sitemap immediately.
 	 * @param urls the URLs to add to this sitemap
 	 * @return this
-	 * @throws IOException when closing of streams has failed.
 	 */
-	public THIS addUrls(Iterable<? extends U> urls) throws IOException {
+	public THIS addUrls(Iterable<? extends U> urls) {
 		for (U url : urls) addUrl(url);
 		return getThis();
 	}
@@ -95,9 +97,8 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 	 * or write out one sitemap immediately.
 	 * @param urls the URLs to add to this sitemap
 	 * @return this
-	 * @throws IOException when closing of streams has failed.
 	 */
-	public THIS addUrls(U... urls) throws IOException {
+	public THIS addUrls(U... urls) {
 		for (U url : urls) addUrl(url);
 		return getThis();
 	}
@@ -215,9 +216,8 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 	/**
 	 * After you've called {@link #write()}, call this to generate a sitemap index of all sitemaps you generated.
 	 * The sitemap index is written to {baseDir}/sitemap_index.xml
-	 * @throws IOException when closing of streams has failed
 	 */
-	public File writeSitemapsWithIndex() throws IOException {
+	public File writeSitemapsWithIndex() {
 		if (!finished) throw new RuntimeException("Sitemaps not generated yet; call write() first");
 		File outFile = new File(baseDir, "sitemap_index.xml");
 		return writeSitemapsWithIndex(outFile);
@@ -227,9 +227,8 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 	 * After you've called {@link #write()}, call this to generate a sitemap index of all sitemaps you generated.
 	 *
 	 * @param outFile the destination file of the sitemap index.
-	 * @throws IOException when closing of streams has failed
 	 */
-	public File writeSitemapsWithIndex(File outFile) throws IOException {
+	public File writeSitemapsWithIndex(File outFile) {
 		if (!finished) throw new RuntimeException("Sitemaps not generated yet; call write() first");
 		SitemapIndexGenerator sig;
 		sig = new SitemapIndexGenerator.Options(baseUrl, outFile).dateFormat(dateFormat).autoValidate(autoValidate).build();

--- a/src/main/java/com/redfin/sitemapgenerator/SitemapIndexGenerator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/SitemapIndexGenerator.java
@@ -228,6 +228,8 @@ public class SitemapIndexGenerator {
                 // TODO gzip? is that legal for a sitemap index?
                 out = new FileWriter(outFile);
                 writeSiteMap(out);
+                out.flush();
+
                 if (autoValidate) SitemapValidator.validateSitemapIndex(outFile);
             } catch (IOException e) {
                 throw new RuntimeException("Problem writing sitemap index file " + outFile, e);

--- a/src/main/java/com/redfin/sitemapgenerator/SitemapIndexGenerator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/SitemapIndexGenerator.java
@@ -1,5 +1,7 @@
 package com.redfin.sitemapgenerator;
 
+import org.xml.sax.SAXException;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -8,8 +10,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Date;
-
-import org.xml.sax.SAXException;
 
 /**
  * Builds a sitemap index, which points only to other sitemaps.
@@ -222,16 +222,26 @@ public class SitemapIndexGenerator {
 	/** Writes out the sitemap index */
 	public void write() {
 		if (!allowEmptyIndex && urls.isEmpty()) throw new RuntimeException("No URLs added, sitemap index would be empty; you must add some URLs with addUrls");
-		try {
-			// TODO gzip? is that legal for a sitemap index?
-			FileWriter out = new FileWriter(outFile);
-			writeSiteMap(out);
-			if (autoValidate) SitemapValidator.validateSitemapIndex(outFile);
-		} catch (IOException e) {
-			throw new RuntimeException("Problem writing sitemap index file " + outFile, e);
-		} catch (SAXException e) {
-			throw new RuntimeException("Problem validating sitemap index file (bug?)", e);
-		}
+        try {
+            FileWriter out = null;
+            try {
+                // TODO gzip? is that legal for a sitemap index?
+                out = new FileWriter(outFile);
+                writeSiteMap(out);
+                if (autoValidate) SitemapValidator.validateSitemapIndex(outFile);
+            } catch (IOException e) {
+                throw new RuntimeException("Problem writing sitemap index file " + outFile, e);
+            } catch (SAXException e) {
+                throw new RuntimeException("Problem validating sitemap index file (bug?)", e);
+            } finally {
+                if(out != null) {
+                    out.close();
+                }
+            }
+        } catch (IOException ex) {
+            throw new RuntimeException("Closing of stream has failed.", ex);
+        }
+
 	}
 	
 	private void writeSiteMap(OutputStreamWriter out) throws IOException {
@@ -254,7 +264,6 @@ public class SitemapIndexGenerator {
 			out.write("  </sitemap>\n");
 		}
 		out.write("</sitemapindex>");
-		out.close();
 	}
 
 }

--- a/src/main/java/com/redfin/sitemapgenerator/SitemapIndexGenerator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/SitemapIndexGenerator.java
@@ -222,27 +222,27 @@ public class SitemapIndexGenerator {
 	/** Writes out the sitemap index */
 	public void write() {
 		if (!allowEmptyIndex && urls.isEmpty()) throw new RuntimeException("No URLs added, sitemap index would be empty; you must add some URLs with addUrls");
-        try {
-            FileWriter out = null;
-            try {
-                // TODO gzip? is that legal for a sitemap index?
-                out = new FileWriter(outFile);
-                writeSiteMap(out);
-                out.flush();
+		try {
+			FileWriter out = null;
+			try {
+				// TODO gzip? is that legal for a sitemap index?
+				out = new FileWriter(outFile);
+				writeSiteMap(out);
+				out.flush();
 
-                if (autoValidate) SitemapValidator.validateSitemapIndex(outFile);
-            } catch (IOException e) {
-                throw new RuntimeException("Problem writing sitemap index file " + outFile, e);
-            } catch (SAXException e) {
-                throw new RuntimeException("Problem validating sitemap index file (bug?)", e);
-            } finally {
-                if(out != null) {
-                    out.close();
-                }
-            }
-        } catch (IOException ex) {
-            throw new RuntimeException("Closing of stream has failed.", ex);
-        }
+				if (autoValidate) SitemapValidator.validateSitemapIndex(outFile);
+			} catch (IOException e) {
+				throw new RuntimeException("Problem writing sitemap index file " + outFile, e);
+			} catch (SAXException e) {
+				throw new RuntimeException("Problem validating sitemap index file (bug?)", e);
+			} finally {
+				if(out != null) {
+					out.close();
+				}
+			}
+		} catch (IOException ex) {
+			throw new RuntimeException("Closing of stream has failed.", ex);
+		}
 
 	}
 	

--- a/src/main/java/com/redfin/sitemapgenerator/SitemapValidator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/SitemapValidator.java
@@ -64,31 +64,36 @@ public class SitemapValidator {
 	}
 	
 	/** Validates an ordinary web sitemap file (NOT a Google-specific sitemap) */
-	public static void validateWebSitemap(File sitemap) throws SAXException, IOException {
+	public static void validateWebSitemap(File sitemap) throws SAXException {
 		lazyLoad();
 		validateXml(sitemap, sitemapSchema);
 	}
 	
 	/** Validates a sitemap index file  */
-	public static void validateSitemapIndex(File sitemap) throws SAXException, IOException {
+	public static void validateSitemapIndex(File sitemap) throws SAXException {
 		lazyLoad();
 		validateXml(sitemap, sitemapIndexSchema);
 	}
 
-	private static void validateXml(File sitemap, Schema schema) throws SAXException, IOException {
-		Validator validator = schema.newValidator();
-		FileReader reader = null;
+	private static void validateXml(File sitemap, Schema schema) throws SAXException {
 		try {
-			reader = new FileReader(sitemap);
-			SAXSource source = new SAXSource(new InputSource(reader));
-			validator.validate(source);
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		} finally {
-			if(reader != null) {
-				reader.close();
+			Validator validator = schema.newValidator();
+			FileReader reader = null;
+			try {
+				reader = new FileReader(sitemap);
+				SAXSource source = new SAXSource(new InputSource(reader));
+				validator.validate(source);
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			} finally {
+				if(reader != null) {
+					reader.close();
+				}
 			}
+		} catch (IOException ex) {
+			throw new RuntimeException("Unable to close stream.", ex);
 		}
+
 	}
 
 }

--- a/src/main/java/com/redfin/sitemapgenerator/SitemapValidator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/SitemapValidator.java
@@ -1,9 +1,7 @@
 package com.redfin.sitemapgenerator;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStream;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
 import javax.xml.transform.sax.SAXSource;
@@ -11,9 +9,10 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
-
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
 
 /** Validates sitemaps and sitemap indexes
  * 
@@ -41,44 +40,55 @@ public class SitemapValidator {
 		SchemaFactory factory =
             SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
 		try {
-			InputStream stream = SitemapValidator.class.getResourceAsStream("sitemap.xsd");
-			if (stream == null) throw new RuntimeException("BUG Couldn't load sitemap.xsd");
-			StreamSource source = new StreamSource(stream);
-			sitemapSchema = factory.newSchema(source);
-			stream.close();
-			
-			stream = SitemapValidator.class.getResourceAsStream("siteindex.xsd");
-			if (stream == null) throw new RuntimeException("BUG Couldn't load siteindex.xsd");
-			source = new StreamSource(stream);
-			sitemapIndexSchema = factory.newSchema(source);
-			stream.close();
+			sitemapSchema = lazyLoad(factory, "sitemap.xsd");
+			sitemapIndexSchema = lazyLoad(factory, "siteindex.xsd");
 		} catch (Exception e) {
 			throw new RuntimeException("BUG", e);
 		}
 	}
+
+	private synchronized static Schema lazyLoad(SchemaFactory factory, String resource) throws IOException, SAXException {
+	    InputStream stream = null;
+
+        try {
+            stream = SitemapValidator.class.getResourceAsStream(resource);
+            if (stream == null) throw new RuntimeException("BUG Couldn't load " + resource);
+            StreamSource source = new StreamSource(stream);
+            return factory.newSchema(source);
+        } finally {
+            if(stream != null) {
+                stream.close();
+            }
+        }
+
+    }
 	
 	/** Validates an ordinary web sitemap file (NOT a Google-specific sitemap) */
-	public static void validateWebSitemap(File sitemap) throws SAXException {
+	public static void validateWebSitemap(File sitemap) throws SAXException, IOException {
 		lazyLoad();
 		validateXml(sitemap, sitemapSchema);
 	}
 	
 	/** Validates a sitemap index file  */
-	public static void validateSitemapIndex(File sitemap) throws SAXException {
+	public static void validateSitemapIndex(File sitemap) throws SAXException, IOException {
 		lazyLoad();
 		validateXml(sitemap, sitemapIndexSchema);
 	}
 
-	private static void validateXml(File sitemap, Schema schema) throws SAXException {
+	private static void validateXml(File sitemap, Schema schema) throws SAXException, IOException {
 		Validator validator = schema.newValidator();
+        FileReader reader = null;
 		try {
-			FileReader reader = new FileReader(sitemap);
+			reader = new FileReader(sitemap);
 			SAXSource source = new SAXSource(new InputSource(reader));
 			validator.validate(source);
-			reader.close();
 		} catch (IOException e) {
 			throw new RuntimeException(e);
-		}
+		} finally {
+		    if(reader != null) {
+		        reader.close();
+            }
+        }
 	}
 
 }

--- a/src/main/java/com/redfin/sitemapgenerator/SitemapValidator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/SitemapValidator.java
@@ -38,7 +38,7 @@ public class SitemapValidator {
 	private synchronized static void lazyLoad() {
 		if (sitemapSchema != null)  return;
 		SchemaFactory factory =
-            SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+			SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
 		try {
 			sitemapSchema = lazyLoad(factory, "sitemap.xsd");
 			sitemapIndexSchema = lazyLoad(factory, "siteindex.xsd");
@@ -48,20 +48,20 @@ public class SitemapValidator {
 	}
 
 	private synchronized static Schema lazyLoad(SchemaFactory factory, String resource) throws IOException, SAXException {
-	    InputStream stream = null;
+		InputStream stream = null;
 
-        try {
-            stream = SitemapValidator.class.getResourceAsStream(resource);
-            if (stream == null) throw new RuntimeException("BUG Couldn't load " + resource);
-            StreamSource source = new StreamSource(stream);
-            return factory.newSchema(source);
-        } finally {
-            if(stream != null) {
-                stream.close();
-            }
-        }
+		try {
+			stream = SitemapValidator.class.getResourceAsStream(resource);
+			if (stream == null) throw new RuntimeException("BUG Couldn't load " + resource);
+			StreamSource source = new StreamSource(stream);
+			return factory.newSchema(source);
+		} finally {
+			if(stream != null) {
+				stream.close();
+			}
+		}
 
-    }
+	}
 	
 	/** Validates an ordinary web sitemap file (NOT a Google-specific sitemap) */
 	public static void validateWebSitemap(File sitemap) throws SAXException, IOException {
@@ -77,7 +77,7 @@ public class SitemapValidator {
 
 	private static void validateXml(File sitemap, Schema schema) throws SAXException, IOException {
 		Validator validator = schema.newValidator();
-        FileReader reader = null;
+		FileReader reader = null;
 		try {
 			reader = new FileReader(sitemap);
 			SAXSource source = new SAXSource(new InputSource(reader));
@@ -85,10 +85,10 @@ public class SitemapValidator {
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		} finally {
-		    if(reader != null) {
-		        reader.close();
-            }
-        }
+			if(reader != null) {
+				reader.close();
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
The streams have to be closed in a finally clause. Otherwise the streams might be left open when an exception has been thrown meanwhile.
(In our production environment this resulted in an "too many open files" error.)