### PR TITLE
add customizable file name for sitemap_index.xml

### DIFF
--- a/src/main/java/com/redfin/sitemapgenerator/SitemapGenerator.java
+++ b/src/main/java/com/redfin/sitemapgenerator/SitemapGenerator.java
@@ -223,6 +223,14 @@ abstract class SitemapGenerator<U extends ISitemapUrl, THIS extends SitemapGener
 
 	/**
 	 * After you've called {@link #write()}, call this to generate a sitemap index of all sitemaps you generated.
+	 * The sitemap index is written to {baseDir}/<customized file name> instead of {baseDir}/sitemap_index.xml
+	 */
+	public File writeSitemapsWithIndex(final String fileName){
+		return writeSitemapsWithIndex(new File(baseDir, fileName));
+	}
+
+	/**
+	 * After you've called {@link #write()}, call this to generate a sitemap index of all sitemaps you generated.
 	 */
 	public String writeSitemapsWithIndexAsString() {
 		return prepareSitemapIndexGenerator(null).writeAsString();


### PR DESCRIPTION
nothing fancy, but just came across a seldom situation last week, which needs a none-standard file name for sitemap_index.xml, it will be then reflected in robots.txt to trigger a re-read from google bot and possibly fix a bad scored website.